### PR TITLE
fix(security): Fix SecurityConfig to disable session management, and unlock api authenticity

### DIFF
--- a/src/main/java/br/com/barberflow/api/SecurityConfig.java
+++ b/src/main/java/br/com/barberflow/api/SecurityConfig.java
@@ -1,10 +1,12 @@
 package br.com.barberflow.api;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
@@ -16,17 +18,20 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .csrf(AbstractHttpConfigurer::disable)
+
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(toH2Console()).permitAll()
                         .anyRequest().authenticated()
                 )
-                .csrf(csrf -> csrf
-                        .ignoringRequestMatchers(toH2Console())
-                )
-                .headers(headers -> headers
-                        .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
-                )
-                .formLogin(form -> form.defaultSuccessUrl("/health", true));
+
+                .httpBasic(Customizer.withDefaults())
+
+                .formLogin(AbstractHttpConfigurer::disable);
+
+        http.headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin));
 
         return http.build();
     }


### PR DESCRIPTION
- [x] Disabled CSRF (Cross-Site Request Forgery) protection, as it is not typically required for stateless APIs.
- [x] Set the session management policy to `STATELESS` to prevent session cookie creation.
- [x] Disabled the default `formLogin()` behavior to stop redirects to a login page.
- [x] Explicitly configured `httpBasic()` as the authentication mechanism for API requests.