### PR TITLE
refactor(user): Create DTO's and Mappers for User API

### DIFF
--- a/src/main/java/br/com/barberflow/api/core/user/controller/UserController.java
+++ b/src/main/java/br/com/barberflow/api/core/user/controller/UserController.java
@@ -1,12 +1,16 @@
 package br.com.barberflow.api.core.user.controller;
 
 import br.com.barberflow.api.core.user.domain.User;
+import br.com.barberflow.api.core.user.dto.UserRequestDTO;
+import br.com.barberflow.api.core.user.dto.UserResponseDTO;
+import br.com.barberflow.api.core.user.mapper.UserMapper;
 import br.com.barberflow.api.core.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/users")
@@ -14,22 +18,28 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+    private final UserMapper userMapper;
 
     @PostMapping
-    public ResponseEntity<User> createUser(@RequestBody User user) {
-        User newUser = userService.createUser(user);
-        return ResponseEntity.status(201).body(newUser);
+    public ResponseEntity<UserResponseDTO> createUser(@RequestBody UserRequestDTO userRequestDTO) {
+        User newUser = userService.createUser(userRequestDTO);
+        UserResponseDTO responseDTO = userMapper.toResponseDTO(newUser);
+        return ResponseEntity.status(201).body(responseDTO);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<User> findUserById(@PathVariable Long id) {
+    public ResponseEntity<UserResponseDTO> findUserById(@PathVariable Long id) {
         User user = userService.findUserById(id);
-        return ResponseEntity.ok(user);
+        UserResponseDTO responseDTO = userMapper.toResponseDTO(user);
+        return ResponseEntity.ok(responseDTO);
     }
 
     @GetMapping
-    public ResponseEntity<List<User>> findAllUsers() {
+    public ResponseEntity<List<UserResponseDTO>> findAllUsers() {
         List<User> users = userService.findAllUsers();
-        return ResponseEntity.ok(users);
+        List<UserResponseDTO> responseDTOs = users.stream()
+                .map(userMapper::toResponseDTO)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responseDTOs);
     }
 }

--- a/src/main/java/br/com/barberflow/api/core/user/dto/UserRequestDTO.java
+++ b/src/main/java/br/com/barberflow/api/core/user/dto/UserRequestDTO.java
@@ -1,0 +1,11 @@
+package br.com.barberflow.api.core.user.dto;
+
+import br.com.barberflow.api.core.user.domain.UserRole;
+
+public record UserRequestDTO(
+        String name,
+        String email,
+        String password,
+        UserRole role
+) {
+}

--- a/src/main/java/br/com/barberflow/api/core/user/dto/UserResponseDTO.java
+++ b/src/main/java/br/com/barberflow/api/core/user/dto/UserResponseDTO.java
@@ -1,0 +1,11 @@
+package br.com.barberflow.api.core.user.dto;
+
+import br.com.barberflow.api.core.user.domain.UserRole;
+
+public record UserResponseDTO(
+        Long id,
+        String name,
+        String email,
+        UserRole role
+) {
+}

--- a/src/main/java/br/com/barberflow/api/core/user/mapper/UserMapper.java
+++ b/src/main/java/br/com/barberflow/api/core/user/mapper/UserMapper.java
@@ -1,0 +1,25 @@
+package br.com.barberflow.api.core.user.mapper;
+
+import br.com.barberflow.api.core.user.domain.User;
+import br.com.barberflow.api.core.user.dto.UserRequestDTO;
+import br.com.barberflow.api.core.user.dto.UserResponseDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+
+    public User toEntity(UserRequestDTO dto) {
+        if (dto == null) {
+            return null;
+        }
+        return new User(null, dto.name(), dto.email(), dto.password(), dto.role());
+    }
+
+    public UserResponseDTO toResponseDTO(User entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return new UserResponseDTO(entity.getId(), entity.getName(), entity.getEmail(), entity.getRole());
+    }
+}

--- a/src/main/java/br/com/barberflow/api/core/user/service/UserService.java
+++ b/src/main/java/br/com/barberflow/api/core/user/service/UserService.java
@@ -1,6 +1,8 @@
 package br.com.barberflow.api.core.user.service;
 
 import br.com.barberflow.api.core.user.domain.User;
+import br.com.barberflow.api.core.user.dto.UserRequestDTO;
+import br.com.barberflow.api.core.user.mapper.UserMapper;
 import br.com.barberflow.api.core.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,8 +14,10 @@ import java.util.List;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final UserMapper userMapper;
 
-    public User createUser(User user) {
+    public User createUser(UserRequestDTO userRequestDTO) {
+        User user = userMapper.toEntity(userRequestDTO);
         return userRepository.save(user);
     }
 


### PR DESCRIPTION
- [x] Created `UserRequestDTO` to model the data required for creating a new user.
- [x] Created `UserResponseDTO` to safely expose user data, **explicitly excluding the `password` field**.
- [x] Implemented a `UserMapper` component to handle the conversion between the `User` entity and its corresponding DTOs.
- [x] Refactored `UserController` to accept `UserRequestDTO` in its `POST` endpoint and return `UserResponseDTO` in all endpoints.
- [x] Refactored `UserService` to accept the `UserRequestDTO` for user creation.